### PR TITLE
Add optional `variant` fields to the presentation comlink protocol

### DIFF
--- a/.changeset/spicy-pandas-repeat.md
+++ b/.changeset/spicy-pandas-repeat.md
@@ -1,0 +1,7 @@
+---
+"@sanity/presentation-comlink": minor
+---
+
+Add optional `variant` protocol fields for editing variants
+
+Every message that carries a `perspective` now also accepts an optional `variant?: string` (the bare variant id, `undefined` when no variant is selected): `presentation/perspective`, `visual-editing/documents`, the `visual-editing/fetch-perspective` response, `loader/perspective`, `loader/query-change`, `loader/query-listen`, `loader/documents` and `preview-kit/documents`. The `visual-editing/fetch-perspective` request data also accepts an optional `handlesVariantChange?: boolean` capability flag, signaling that `<VisualEditing>` handles variant changes without a full page reload. All new fields are optional, so the protocol stays backward and forward compatible.

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,15 +1,16 @@
 name: Publish Pull Requests with pkg.pr.new
 
-permissions:
-  pull-requests: write
-
 on:
   pull_request:
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize, labeled, reopened]
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+concurrency:
+  group: pkg-pr-new-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   publish:
@@ -17,10 +18,205 @@ jobs:
       github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger: preview')
 
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
-      - name: Build packages
+
+      - name: Build
         run: pnpm build
-      - name: Publish to pkg.pr.new
-        run: pnpm dlx pkg-pr-new publish --no-template './packages/comlink' './packages/presentation-comlink'
+
+      - name: Detect changed packages from changesets
+        id: changed-packages
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          mapfile -t changeset_files < <(
+            git diff --name-only "origin/$BASE_REF"...HEAD -- '.changeset/*.md'
+          )
+
+          filtered_changeset_files=()
+          for file in "${changeset_files[@]}"; do
+            if [[ "$file" == ".changeset/README.md" ]]; then
+              continue
+            fi
+            if [[ "$file" == .changeset/*.md ]]; then
+              filtered_changeset_files+=("$file")
+            fi
+          done
+          changeset_files=("${filtered_changeset_files[@]}")
+
+          if [ ${#changeset_files[@]} -eq 0 ]; then
+            echo "has_changed_packages=false" >> "$GITHUB_OUTPUT"
+            echo "package_paths=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          parser_script="$(mktemp)"
+          cat > "$parser_script" <<'NODE'
+          const fs = require("node:fs")
+          const files = process.argv.slice(2)
+          const paths = new Set()
+
+          for (const file of files) {
+            const content = fs.readFileSync(file, "utf8")
+            const match = content.match(/^---\n([\s\S]*?)\n---/)
+            if (!match) continue
+
+            for (const line of match[1].split("\n")) {
+              const packageMatch = line.match(/^\s*['"]([^'"]+)['"]\s*:\s*(major|minor|patch)\s*$/)
+              if (!packageMatch) continue
+
+              const packageName = packageMatch[1]
+              if (!packageName.startsWith("@sanity/")) continue
+
+              const packagePath = `./packages/${packageName.slice("@sanity/".length)}`
+              if (fs.existsSync(packagePath)) {
+                paths.add(packagePath)
+              }
+            }
+          }
+
+          for (const path of [...paths].sort()) {
+            console.log(path)
+          }
+          NODE
+
+          mapfile -t packages < <(node "$parser_script" "${changeset_files[@]}")
+          rm -f "$parser_script"
+
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "has_changed_packages=false" >> "$GITHUB_OUTPUT"
+            echo "package_paths=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changed_packages=true" >> "$GITHUB_OUTPUT"
+          echo "package_paths=${packages[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish preview packages
+        if: steps.changed-packages.outputs.has_changed_packages == 'true'
+        env:
+          PACKAGE_PATHS: ${{ steps.changed-packages.outputs.package_paths }}
+        run: pnpm dlx pkg-pr-new publish $PACKAGE_PATHS --pnpm --no-template --comment=off --json output.json
+
+      - name: Post or update comment
+        uses: actions/github-script@v9
+        env:
+          HAS_CHANGED_PACKAGES: ${{ steps.changed-packages.outputs.has_changed_packages }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('node:fs')
+
+            const hasChangedPackages = process.env.HAS_CHANGED_PACKAGES === 'true'
+            const output = hasChangedPackages
+              ? JSON.parse(fs.readFileSync('output.json', 'utf8'))
+              : {packages: []}
+
+            const PACKAGE_MANAGERS = [
+              {
+                name: 'pnpm',
+                installCommand: 'pnpm install',
+                logoUrl: 'https://avatars.githubusercontent.com/u/21320719?s=200&v=4',
+              },
+              {
+                name: 'npm',
+                installCommand: 'npm install',
+                logoUrl: 'https://avatars.githubusercontent.com/u/6078720?s=200&v=4',
+              },
+            ]
+
+            const BOT_COMMENT_IDENTIFIER = '<!-- pkg.pr.new -->'
+            const BACKTICKS = '```'
+
+            function renderPackages(pkgManager, pkgs) {
+              return pkgs
+                .map(
+                  (pkg) =>
+                    `##### :package: \`${pkg.name}\`
+            ${BACKTICKS}sh
+            ${pkgManager.installCommand} ${pkg.url}
+            ${BACKTICKS}
+            `,
+                )
+                .join('\n')
+            }
+
+            function renderInstallInstructions() {
+              return PACKAGE_MANAGERS.map(
+                (pkgManager) =>
+                  `<details${pkgManager.name === 'pnpm' ? ' open' : ''}>
+            <summary><img height="16" align="center" alt="${pkgManager.name} logo" src="${pkgManager.logoUrl}" /> <b>Using ${pkgManager.name}</b></summary>
+
+            ${renderPackages(pkgManager, output.packages)}
+
+            </details>
+            `,
+              ).join('\n')
+            }
+
+            const sha = context.payload.pull_request?.head?.sha ?? context.sha
+
+            const body = hasChangedPackages
+              ? `## Preview this PR with [pkg.pr.new](https://pkg.pr.new)
+
+            ${renderInstallInstructions()}
+
+            [View Commit](${`https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sha}`}) (${sha})
+
+            ${BOT_COMMENT_IDENTIFIER}
+            `
+              : `## Preview this PR with [pkg.pr.new](https://pkg.pr.new)
+
+            No packages were published, no changesets were found.
+
+            [View Commit](${`https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sha}`}) (${sha})
+
+            ${BOT_COMMENT_IDENTIFIER}
+            `
+
+            async function findBotComment(issueNumber) {
+              if (!issueNumber) return null
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              })
+              return comments.data.find((comment) => comment.body.includes(BOT_COMMENT_IDENTIFIER))
+            }
+
+            async function createOrUpdateComment(issueNumber) {
+              if (!issueNumber) {
+                console.log('No issue number provided. Cannot post or update comment.')
+                return
+              }
+
+              const existingComment = await findBotComment(issueNumber)
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body,
+                })
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: issueNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body,
+                })
+              }
+            }
+
+            if (context.eventName === 'pull_request') {
+              await createOrUpdateComment(context.issue.number)
+            } else {
+              throw new Error('This job can only run for pull requests')
+            }

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,26 @@
+name: Publish Pull Requests with pkg.pr.new
+
+permissions:
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+jobs:
+  publish:
+    if: >
+      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger: preview')
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Build packages
+        run: pnpm build
+      - name: Publish to pkg.pr.new
+        run: pnpm dlx pkg-pr-new publish --no-template './packages/comlink' './packages/presentation-comlink'

--- a/packages/presentation-comlink/src/types.ts
+++ b/packages/presentation-comlink/src/types.ts
@@ -113,6 +113,10 @@ export type VisualEditingControllerMsg =
       type: 'presentation/perspective'
       data: {
         perspective: ClientPerspective
+        /**
+         * The selected editing variant (bare variant id). Undefined when no variant is selected.
+         */
+        variant?: string
       }
     }
   /**
@@ -197,6 +201,10 @@ export type VisualEditingNodeMsg =
         projectId?: string
         dataset?: string
         perspective: ClientPerspective
+        /**
+         * The selected editing variant (bare variant id). Undefined when no variant is selected.
+         */
+        variant?: string
         documents: ContentSourceMapDocuments
       }
     }
@@ -267,12 +275,20 @@ export type VisualEditingNodeMsg =
         | undefined
         | {
             /**
-             * Specifies if <VisualEditing> has a `onPerspecticeChange` prop, which signals perspective changes are handled and should not trigger full page reload
+             * Specifies if <VisualEditing> has a `onPerspectiveChange` prop, which signals perspective changes are handled and should not trigger full page reload
              */
             handlesPerspectiveChange: boolean
+            /**
+             * Specifies if <VisualEditing> has an `onVariantChange` prop, which signals variant changes are handled and should not trigger a full page reload
+             */
+            handlesVariantChange?: boolean
           }
       response: {
         perspective: ClientPerspective
+        /**
+         * The selected editing variant (bare variant id). Undefined when no variant is selected.
+         */
+        variant?: string
       }
     }
   | {
@@ -317,6 +333,10 @@ export type LoaderControllerMsg =
         projectId: string
         dataset: string
         perspective: ClientPerspective
+        /**
+         * The selected editing variant (bare variant id). Undefined when no variant is selected.
+         */
+        variant?: string
       }
     }
   | {
@@ -325,6 +345,10 @@ export type LoaderControllerMsg =
         projectId: string
         dataset: string
         perspective: ClientPerspective
+        /**
+         * The selected editing variant (bare variant id). Undefined when no variant is selected.
+         */
+        variant?: string
         query: string
         params: QueryParams
         result: any
@@ -343,6 +367,10 @@ export type LoaderNodeMsg =
         projectId: string
         dataset: string
         perspective: ClientPerspective
+        /**
+         * The selected editing variant (bare variant id). Undefined when no variant is selected.
+         */
+        variant?: string
         query: string
         params: QueryParams
         /**
@@ -362,6 +390,10 @@ export type LoaderNodeMsg =
         projectId: string
         dataset: string
         perspective: ClientPerspective
+        /**
+         * The selected editing variant (bare variant id). Undefined when no variant is selected.
+         */
+        variant?: string
         documents: ContentSourceMapDocuments
       }
     }
@@ -389,6 +421,10 @@ export type PreviewKitNodeMsg = {
     projectId: string
     dataset: string
     perspective: ClientPerspective
+    /**
+     * The selected editing variant (bare variant id). Undefined when no variant is selected.
+     */
+    variant?: string
     documents: ContentSourceMapDocuments
   }
 }


### PR DESCRIPTION
## Summary

Sanity Studio is adding support for **editing variants**, and the selected variant needs to flow from the studio through Presentation Tool into preview frontends, following the same paths `perspective` uses today. This PR adds the protocol fields for that (types-only, fully backward compatible):

- `variant?: string` added next to every `perspective` field: `presentation/perspective`, `visual-editing/documents`, the `visual-editing/fetch-perspective` response, `loader/perspective`, `loader/query-change`, `loader/query-listen`, `loader/documents`, and `preview-kit/documents`
- `handlesVariantChange?: boolean` capability flag added to the `visual-editing/fetch-perspective` request data, mirroring `handlesPerspectiveChange`
- Fixed the `onPerspecticeChange` → `onPerspectiveChange` typo in the existing TSDoc (field name unchanged)

The wire value is the bare variant id (e.g. `Ab12cd34`), never the full variant document id; `undefined` means no variant is selected. All new fields are optional so old senders/receivers interop cleanly across the postMessage boundary.

Includes a changeset for a minor release of `@sanity/presentation-comlink`. This is phase 1 of the rollout — the sanity monorepo (`sanity/presentation`) and `sanity-io/visual-editing` will bump to the released version to send/consume these fields.

## Test plan

- [x] `pnpm build`
- [x] `pnpm type-check`
- [x] `pnpm lint` (0 errors; remaining warnings pre-existing)
- [x] `pnpm test`