### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a pnpm + Turborepo monorepo for the `@sanity/comlink` cross-window messaging
+libraries. Standard commands are documented in `README.md` and defined in the root
+`package.json` scripts; prefer those. Notes below cover non-obvious caveats only.
+
+### Layout
+- `packages/comlink` — core library (`@sanity/comlink`).
+- `packages/presentation-comlink` — Sanity-internal helpers (`@sanity/presentation-comlink`).
+- `apps/playground` — Vite + React demo app that exercises the library end to end.
+
+### Running / testing
+- Node 22 and pnpm are already provisioned; dependencies are installed by the startup
+  update script (`pnpm install`). No extra system deps, services, secrets, or network
+  access are required.
+- Root scripts: `pnpm build` (packages only — the root `build` filters out `apps/*`),
+  `pnpm type-check`, `pnpm lint` (oxlint, type-aware), `pnpm test` (vitest via turbo).
+- `pnpm test` currently reports "No test files found" and passes via
+  `--pass-with-no-tests`; that is expected on `main`, not a failure.
+- `pnpm lint` emits pre-existing warnings (currently ~20) but 0 errors; a clean lint run
+  still has warnings.
+- `pnpm dev` runs `turbo run dev`: it watch-builds the packages AND starts the playground
+  Vite dev server at http://localhost:5173/ (routes `/` and `/frame/`). It is a
+  persistent process — run it in the background (e.g. tmux), not as a blocking command.
+- `pnpm install` prints an "Ignored build scripts: esbuild" warning. This is harmless —
+  Vite/Vitest still build and run correctly, so no `pnpm approve-builds` step is needed.
+
+### Playground hello-world
+Open http://localhost:5173/, click "Add Frame" (status changes to "1 connected"), type a
+message and click Send — it is delivered to the iframe Node, confirming the comlink
+handshake and message passing work.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `@sanity/comlink` monorepo (pnpm + Turborepo) and documents non-obvious startup/run caveats for future cloud agents.

No application code was changed — the only file added is `AGENTS.md`.

## Environment

- Node 22 and pnpm 10.34.5 are pre-provisioned; dependency refresh is handled by the startup update script (`pnpm install`).
- No system deps, external services, secrets, or network access required.

## Verified commands

All run from the repo root:

| Task | Command | Result |
| --- | --- | --- |
| Install | `pnpm install` | OK (harmless "Ignored build scripts: esbuild" warning) |
| Build (packages) | `pnpm build` | 2/2 tasks succeeded |
| Type-check | `pnpm type-check` | passed |
| Lint | `pnpm lint` | 0 errors (~20 pre-existing warnings) |
| Test | `pnpm test` | passed (`--pass-with-no-tests`; no test files on `main`) |
| Run (dev) | `pnpm dev` | Vite playground at http://localhost:5173/ |

## Hello-world validation

Ran the playground dev server and exercised the core cross-window messaging: added a frame (status went `idle` → `1 connected`) and sent a `hello world` message that was delivered to the iframe Node.

[comlink_playground_demo.mp4](https://cursor.com/agents/bc-626581f2-7aa8-4ae9-a748-309b8392390f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomlink_playground_demo.mp4)

[Frame connected](https://cursor.com/agents/bc-626581f2-7aa8-4ae9-a748-309b8392390f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomlink_connected.webp)
[Message delivered to iframe](https://cursor.com/agents/bc-626581f2-7aa8-4ae9-a748-309b8392390f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomlink_message_delivered.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-626581f2-7aa8-4ae9-a748-309b8392390f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-626581f2-7aa8-4ae9-a748-309b8392390f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

