### PR TITLE
chore: stop publishing src and CHANGELOG.md

### DIFF
--- a/packages/comlink/package.json
+++ b/packages/comlink/package.json
@@ -17,9 +17,7 @@
     "directory": "packages/comlink"
   },
   "files": [
-    "dist",
-    "src",
-    "CHANGELOG.md"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/presentation-comlink/package.json
+++ b/packages/presentation-comlink/package.json
@@ -13,9 +13,7 @@
     "directory": "packages/presentation-comlink"
   },
   "files": [
-    "dist",
-    "src",
-    "CHANGELOG.md"
+    "dist"
   ],
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes `src` and `CHANGELOG.md` from the `files` field in both `@sanity/comlink` and `@sanity/presentation-comlink`, so npm publishes only the built `dist` output.

No changeset — packaging-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f4b37c6-ce3e-42c6-90be-f20f059df1b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f4b37c6-ce3e-42c6-90be-f20f059df1b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

