### PR TITLE
chore: remove explicit browserslist config

### DIFF
--- a/.changeset/remove-browserslist-config.md
+++ b/.changeset/remove-browserslist-config.md
@@ -1,0 +1,6 @@
+---
+"@sanity/comlink": patch
+"@sanity/presentation-comlink": patch
+---
+
+Remove explicit `browserslist` config and `@sanity/browserslist-config` dependency. Builds fall back to the same defaults from `@sanity/pkg-utils` with identical output.

--- a/packages/comlink/package.config.ts
+++ b/packages/comlink/package.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   tsdoc: false,
   tsconfig: 'tsconfig.build.json',
   runtime: 'browser',
+  strictOptions: {
+    noImplicitBrowsersList: 'off',
+  },
 })

--- a/packages/comlink/package.json
+++ b/packages/comlink/package.json
@@ -51,13 +51,11 @@
     "xstate": "catalog:"
   },
   "devDependencies": {
-    "@sanity/browserslist-config": "catalog:",
     "@sanity/pkg-utils": "catalog:",
     "@sanity/tsconfig": "catalog:",
     "typescript": "catalog:",
     "vitest": "^4.1.10"
   },
-  "browserslist": "extends @sanity/browserslist-config",
   "engines": {
     "node": ">=20.19 <22 || >=22.12"
   }

--- a/packages/presentation-comlink/package.config.ts
+++ b/packages/presentation-comlink/package.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   tsdoc: false,
   tsconfig: 'tsconfig.build.json',
   runtime: 'browser',
+  strictOptions: {
+    noImplicitBrowsersList: 'off',
+  },
 })

--- a/packages/presentation-comlink/package.json
+++ b/packages/presentation-comlink/package.json
@@ -47,13 +47,11 @@
     "xstate": "catalog:"
   },
   "devDependencies": {
-    "@sanity/browserslist-config": "catalog:",
     "@sanity/pkg-utils": "catalog:",
     "@sanity/tsconfig": "catalog:",
     "typescript": "catalog:",
     "vitest": "^4.1.10"
   },
-  "browserslist": "extends @sanity/browserslist-config",
   "engines": {
     "node": ">=20.19 <22 || >=22.12"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@sanity/browserslist-config':
-      specifier: 1.0.5
-      version: 1.0.5
     '@sanity/pkg-utils':
       specifier: 12.0.0
       version: 12.0.0
@@ -119,9 +116,6 @@ importers:
         specifier: 'catalog:'
         version: 5.32.5
     devDependencies:
-      '@sanity/browserslist-config':
-        specifier: 'catalog:'
-        version: 1.0.5
       '@sanity/pkg-utils':
         specifier: 'catalog:'
         version: 12.0.0(@babel/runtime@7.29.7)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.1)(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
@@ -150,9 +144,6 @@ importers:
         specifier: 'catalog:'
         version: 5.32.5
     devDependencies:
-      '@sanity/browserslist-config':
-        specifier: 'catalog:'
-        version: 1.0.5
       '@sanity/pkg-utils':
         specifier: 'catalog:'
         version: 12.0.0(@babel/runtime@7.29.7)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.1)(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,6 @@ allowBuilds:
   esbuild: false
 
 catalog:
-  '@sanity/browserslist-config': 1.0.5
   '@sanity/pkg-utils': 12.0.0
   '@sanity/tsconfig': 2.2.1
   typescript: 7.0.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the package-level `browserslist` field and `@sanity/browserslist-config` dependency from `@sanity/comlink` and `@sanity/presentation-comlink`.

## Why this is a patch

`@sanity/pkg-utils` already falls back to the same `@sanity/browserslist-config` query when `browserslist` is absent. Before/after `dist/` comparison for both packages was byte-identical (`index.js`, `index.d.ts`, and maps), so this is not a breaking change to published build output.

## Changes

- Drop `"browserslist": "extends @sanity/browserslist-config"` from both package.json files
- Remove `@sanity/browserslist-config` from package devDependencies and the pnpm catalog
- Set `strictOptions.noImplicitBrowsersList: 'off'` so builds stay quiet while relying on the pkg-utils default
- Patch changeset for both packages

## Verification

- `pnpm build` succeeds with no browserslist warnings
- Dist artifacts match pre-change baseline
- `pnpm type-check` and `pnpm lint` pass (lint warnings only, pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2dd5f11-0f1b-4287-8862-ad015682fb9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2dd5f11-0f1b-4287-8862-ad015682fb9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

